### PR TITLE
Remove layout-styled-components dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@types/styled-components": "^4.1.19",
-    "layout-styled-components": "^0.1.10",
     "react-animations": "^1.0.0",
     "react-intersection-observer": "^8.24.2",
     "reveal": "^0.0.4",

--- a/src/AnimatedTitle.tsx
+++ b/src/AnimatedTitle.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as L from 'layout-styled-components';
 import { Reveal } from './Reveal';
 
 export const AnimatedTitle: React.FC<
@@ -9,13 +8,25 @@ export const AnimatedTitle: React.FC<
     delay?: number;
   } & React.HTMLAttributes<any>
 > = ({ children, delay = 100, spaceBetweenWords = 8, ...rest }) => {
+  const titleStyles = {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  } as React.CSSProperties;
+
+  const wordStyles = {
+    marginRight: spaceBetweenWords,
+  } as React.CSSProperties;
+
   return (
-    <L.Horizontal wrap center spaceAll={spaceBetweenWords}>
+    <div style={titleStyles}>
       {children.split(' ').map((word, index) => (
-        <Reveal key={index} delay={index * delay}>
+        <Reveal key={index} delay={index * delay} style={wordStyles}>
           <div {...rest}>{word}</div>
         </Reveal>
       ))}
-    </L.Horizontal>
+    </div>
   );
 };

--- a/src/Reveal.tsx
+++ b/src/Reveal.tsx
@@ -1,7 +1,6 @@
 import { VisibilityProperty } from 'csstype';
 import React, { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { CSSObject } from 'styled-components';
 import { Animation } from './reveal-animations';
 
 export enum RevealMode {
@@ -15,7 +14,7 @@ export const Reveal: React.FC<{
   children?: any;
   mode?: RevealMode;
   debugName?: string;
-  style?: CSSObject;
+  style?: React.CSSProperties;
   onShowDone?: () => void;
   wait?: boolean;
 }> = ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,7 +975,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/styled-components@^4.1.18", "@types/styled-components@^4.1.19":
+"@types/styled-components@^4.1.19":
   version "4.1.19"
   resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.19.tgz#535b455d7744fda1608c605df82c0800eda61a09"
   integrity sha512-nDkoTQ8ItcJiyEvTa24TwsIpIfNKCG+Lq0LvAwApOcjQ8OaeOOCg66YSPHBePHUh6RPt1LA8aEzRlgWhQPFqPg==
@@ -4368,16 +4368,6 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-layout-styled-components@^0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/layout-styled-components/-/layout-styled-components-0.1.10.tgz#c06b6ede9a9169d5dd1b4af50904744654b1af5d"
-  integrity sha512-TzNjngobcRbjCN9z/qtBth21+2S1JwCM5aHITCpwKqwF8+lZCC+chymG7DlgaqhPOO3TshlKELsDWl9qzdEnAA==
-  dependencies:
-    "@types/styled-components" "^4.1.18"
-    polished "^3.4.1"
-    styled-components "^4.3.2"
-    styled-mixins "^0.1.8"
-
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -5386,13 +5376,6 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
-
-polished@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.1.tgz#1eb5597ec1792206365635811d465751f5cbf71c"
-  integrity sha512-GflTnlP5rrpDoigjczEkS6Ye7NDA4sFvAnlr5hSDrEvjiVj97Xzev3hZlLi3UB27fpxyTS9rWU64VzVLWkG+mg==
-  dependencies:
-    "@babel/runtime" "^7.4.5"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -6531,7 +6514,7 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-styled-components@^4.3.2, styled-components@^4.4.0:
+styled-components@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.0.tgz#4e381e2dab831d0e6ea431c2840a96323e84e21b"
   integrity sha512-xQ6vTI/0zNjZ1BBDRxyjvBddrxhQ3DxjeCdaLM1lSn5FDnkTOQgRkmWvcUiTajqc5nJqKVl+7sUioMqktD0+Zw==
@@ -6549,14 +6532,6 @@ styled-components@^4.3.2, styled-components@^4.4.0:
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
-
-styled-mixins@^0.1.8:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/styled-mixins/-/styled-mixins-0.1.10.tgz#220685806258de004c864d52b7ea0ba8b373e18c"
-  integrity sha512-pQPl/TjMTumaJBuAL3agVBO3ZOkszCEJuSpdNy2zwy80NotIVtSn6iBTMoe0FRmN5jCX9lRgf7TCdWL1+ZtWJg==
-  dependencies:
-    polished "^3.4.1"
-    styled-components "^4.3.2"
 
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"


### PR DESCRIPTION
Removes the `layout-styled-components` library and removes a `styled-components` reference in `Reveal.tsx` as asked in #11.